### PR TITLE
Typo in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd ./DeepSimulator/
 
 ## Install all required modules
 ```
-./install
+./install.sh
 ```
 
 # Examples


### PR DESCRIPTION
should be './install.sh' rather than './install'