### PR TITLE
Switch to conda activate/deactivate

### DIFF
--- a/base_caller/albacore_2.3.1/download_and_install.sh
+++ b/base_caller/albacore_2.3.1/download_and_install.sh
@@ -1,7 +1,7 @@
 conda remove --name basecall --all -y
 conda create --name basecall python=3.6 -y
-source activate basecall
+source $CONDA_PREFIX/etc/profile.d/conda.sh
+conda activate basecall
 wget -q https://mirror.oxfordnanoportal.com/software/analysis/ont_albacore-2.3.1-cp36-cp36m-manylinux1_x86_64.whl
 pip install ont_albacore-2.3.1-cp36-cp36m-manylinux1_x86_64.whl
 rm -f ont_albacore-2.3.1-cp36-cp36m-manylinux1_x86_64.whl
-

--- a/case_study.sh
+++ b/case_study.sh
@@ -6,7 +6,7 @@ while [[ -n $1 ]]; do
         case $1 in
                 -f | --filename )       shift
                                                 FULLFILE=$1
-                                                ;;                      
+                                                ;;
         esac
         shift
 done
@@ -22,8 +22,8 @@ PREFIX="signal"
 # we should make a tmp directory named after the input file to
 # store the tmp files
 mkdir -p $FILENAME
-
-source activate tensorflow_cdpm
+source $CONDA_PREFIX/etc/profile.d/conda.sh
+conda activate tensorflow_cdpm
 # preprocessing, sampling the read
 # satisfy the converage and length distritubtion requirement
 echo "Executing the preprocessing step..."
@@ -40,11 +40,11 @@ python2 ./util/genome_sampling.py \
 	-K 0 \
 	-l 8000 \
 	-d 3 \
-	-S 0 
+	-S 0
 
 # pore model translation
 # convert the signal to the original range
-# signal duplication 
+# signal duplication
 # done within pore model
 echo "Finished the preprocessing step!"
 echo "Running the context-dependent pore model..."
@@ -79,13 +79,13 @@ python2 ./pore_model/src/context_simulator.py \
 # python2 ./signal_to_fast5/fast5_modify_signal.py \
 # 	-i ./signal_to_fast5/template.fast5 \
 # 	-s ${signal_dir} \
-# 	-d ./fast5 
+# 	-d ./fast5
 
 # basecalling using albacore
 
 echo "Finished format converting!"
 echo "Running Albacore..."
-source activate basecall
+conda activate basecall
 FAST5_DIR="$FILENAME/fast5"
 FASTQ_DIR="$FILENAME/fastq"
 rm -rf $FASTQ_DIR/*
@@ -93,7 +93,7 @@ mkdir -p $FASTQ_DIR
 read_fast5_basecaller.py -i $FAST5_DIR -s $FASTQ_DIR \
 	-c r94_450bps_linear.cfg -o fastq -t 56
 
-source activate tensorflow_cdpm
+conda activate tensorflow_cdpm
 
 # check result
 echo "Basecalling finished!"

--- a/deep_simulator.sh
+++ b/deep_simulator.sh
@@ -203,8 +203,9 @@ done
 #---------------------------------------------------------#
 ##### ===== Part 0: initial argument check ====== #########
 #---------------------------------------------------------#
-
+source $CONDA_PREFIX/etc/profile.d/conda.sh
 # ------ check home directory ---------- #
+
 if [ ! -d "$home" ]
 then
 	echo "home directory $home not exist " >&2
@@ -246,12 +247,12 @@ PREALI="align"
 # we should make a tmp directory named after the input file to
 # store the tmp files
 echo "Pre-process input genome..."
-source activate tensorflow_cdpm
+conda activate tensorflow_cdpm
 python2 $home/util/genome_preprocess.py \
 	-i $FULLFILE \
 	-o $FILENAME/processed_genome \
 	-r 1
-source deactivate
+conda deactivate
 echo "Pre-process input genome done!"
 
 # preprocessing, sampling the read
@@ -264,7 +265,7 @@ then
 fi
 if [ $SAMPLE_NUM -gt 0 ]
 then
-	source activate tensorflow_cdpm
+	conda activate tensorflow_cdpm
 	python2 $home/util/genome_sampling.py \
 		-i $FILENAME/processed_genome \
 		-p $FILENAME/sampled_read \
@@ -274,7 +275,7 @@ then
 		-d $SAMPLE_MODE \
 		-S $RANDOM_SEED \
 		$circular
-	source deactivate
+	conda deactivate
 else
 	cp $FILENAME/processed_genome $FILENAME/sampled_read.fasta
 fi
@@ -282,7 +283,7 @@ echo "Finished the preprocessing step!"
 
 # pore model translation
 # convert the signal to the original range
-# signal duplication 
+# signal duplication
 # done within pore model
 rm -rf $FILENAME/signal/*
 if [ $SIG_OUT -eq 1 ]
@@ -334,7 +335,7 @@ if [ $SIMULATOR_MODE -eq 0 ]
 then
 	echo "Running the context-dependent pore model..."
 	#-> context-dependent simulator
-	source activate tensorflow_cdpm
+	conda activate tensorflow_cdpm
 	export DeepSimulatorHome=$home
 	python2 $home/pore_model/src/context_simulator.py \
 		-i $FILENAME/sampled_read.fasta \
@@ -347,11 +348,11 @@ then
 		-F $FILENAME/fast5 \
 		-T $home/util/$fast5_template \
 		$perf_mode $align_out $sig_out
-	source deactivate
+	conda deactivate
 else
 	echo "Running the context-independent pore model..."
 	#-> contect-independent simulator
-	source activate tensorflow_cdpm
+	conda activate tensorflow_cdpm
 	python2 $home/pore_model/src/kmer_simulator.py \
 		-i $FILENAME/sampled_read.fasta \
 		-p $FILENAME/signal/$PREFIX \
@@ -363,7 +364,7 @@ else
 		-F $FILENAME/fast5 \
 		-T $home/util/$fast5_template \
 		$perf_mode $align_out $sig_out
-	source deactivate
+	conda deactivate
 fi
 echo "Finished generate the simulated signals and fast5 files!"
 
@@ -391,10 +392,10 @@ then
 		--cpu_threads_per_caller $THREAD_NUM --num_callers 1
 else
 	echo "   Basecalling with Albacore..."
-	source activate basecall
+	conda activate basecall
 	read_fast5_basecaller.py -i $FAST5_DIR -s $FASTQ_DIR \
 		-c r94_450bps_linear.cfg -o fastq -t $THREAD_NUM
-	source deactivate
+	conda deactivate
 fi
 echo "Basecalling finished!"
 
@@ -425,4 +426,3 @@ rm -f $FILENAME/test.fastq
 
 #---------- exit -----------#
 exit 0
-

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-
+source $CONDA_PREFIX/etc/profile.d/conda.sh
 
 #-> 1. install tensorflow_cdpm
 conda remove --name tensorflow_cdpm --all -y
 conda create --name tensorflow_cdpm python=2.7 -y
-source activate tensorflow_cdpm
+conda activate tensorflow_cdpm
 pip install tensorflow==1.2.1
 pip install tflearn==0.3.2
 pip install tqdm==4.19.4
@@ -12,7 +12,7 @@ pip install scipy==0.18.1
 pip install h5py==2.7.1
 pip install numpy==1.13.1
 pip install scikit-learn==0.20.3
-source deactivate
+conda deactivate
 
 #-> 2. install basecaller
 #--| 2.1 install albacore_2.3.1

--- a/pore_model.sh
+++ b/pore_model.sh
@@ -7,7 +7,7 @@ then
 	echo "                         1 for kmer official pore_model "
 	exit
 fi
-
+source $CONDA_PREFIX/etc/profile.d/conda.sh
 
 #------ read input arguments ---------#
 FULLFILE=$1
@@ -31,25 +31,24 @@ mkdir -p $tmp_root
 if [ $CONTEXT -eq 0 ]
 then
 	#-> context-dependent pore model
-	source activate tensorflow_cdpm
+	conda activate tensorflow_cdpm
 	export DeepSimulatorHome=$home
 	python2 $home/pore_model/src/context_simulator.py \
 		-i $FULLFILE -p $PREFIX -l $PREFIX -t $THREAD_NUM \
 		-F $tmp_root -T $home/util/$TEMPLATE_FILE \
 		--perfect True --sigout True
-	source deactivate
+	conda deactivate
 else
 	#-> official kmer pore model
-	source activate tensorflow_cdpm
+	conda activate tensorflow_cdpm
 	python2 $home/pore_model/src/kmer_simulator.py \
 		-i $FULLFILE -p $PREFIX -l $PREFIX -t $THREAD_NUM \
 		-F $tmp_root -T $home/util/$TEMPLATE_FILE \
 		-m $home/pore_model/model/$MODEL_FILE \
 		--perfect True --sigout True
-	source deactivate
+	conda deactivate
 fi
 
 
 #---- remove tmp_dir ---#
 rm -rf $tmp_root
-

--- a/train_pore_model.sh
+++ b/train_pore_model.sh
@@ -6,11 +6,11 @@ while [[ -n $1 ]]; do
         case $1 in
                 -i | --input )       shift
                                                 INPUT=$1
-                                                ;;                      
+                                                ;;
         esac
         shift
 done
-
+source $CONDA_PREFIX/etc/profile.d/conda.sh
 
 # preprocessing
 echo "Preprocess data..."
@@ -35,7 +35,6 @@ echo "Data preprocessing finished!!"
 
 # run the pore model simulation part
 cd ../src
-source activate tensorflow_cdpm
+conda activate tensorflow_cdpm
 python2 main_train.py
-source deactivate
-
+conda deactivate


### PR DESCRIPTION
I tried to find/replace all instances in the shell scripts such as 
```diff
- source activate tensorflow_cdpm
+ conda activate tensorflow_cdpm
```
and
```diff
- source deactivate
+ source deactivate
```

The use of conda commands from within a subshell also requires the sourcing of the script $CONDA_PREFIX/etc/profile.d/conda.sh (see for instance, [this issue](https://github.com/conda/conda/issues/7980)).

My code editor (atom) also stripped out a few trailing spaces.


