### PR TITLE
Use a readlinkf.sh implementation in the repo instead of native readlink

### DIFF
--- a/deep_simulator.sh
+++ b/deep_simulator.sh
@@ -217,7 +217,7 @@ then
 	echo "home directory $home not exist " >&2
 	exit 1
 fi
-home=`readlink -f $home`
+home=`$home/readlinkf.sh $home`
 
 #----------- check input genome  -----------#
 if [ ! -s "$FULLFILE" ]
@@ -225,7 +225,7 @@ then
 	echo "input input_genome is null !!" >&2
 	exit 1
 fi
-FULLFILE=`readlink -f $FULLFILE`
+FULLFILE=`$home/readlinkf.sh $FULLFILE`
 #-> get query_name
 fulnam=`basename $FULLFILE`
 relnam=${fulnam%.*}
@@ -236,7 +236,7 @@ then
 	out_root=${relnam}_DeepSimu
 fi
 mkdir -p $out_root
-out_root=`readlink -f $out_root`
+out_root=`$home/readlinkf.sh $out_root`
 
 
 #--------------------------------------------------------#

--- a/readlinkf.sh
+++ b/readlinkf.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Below is an implementation of readlink -f
+# Taken from https://stackoverflow.com/a/1116890/1709587, authored by
+# Keith Smith, and CC-licensed.
+# This is used in DeepSimulator to support readlink -f behaviour on macOS,
+# since the default readlink implementation on macOS doesn't accept the -f
+# flag.
+
+TARGET_FILE=$1
+
+cd `dirname $TARGET_FILE`
+TARGET_FILE=`basename $TARGET_FILE`
+
+# Iterate down a (possible) chain of symlinks
+while [ -L "$TARGET_FILE" ]
+do
+    TARGET_FILE=`readlink $TARGET_FILE`
+    cd `dirname $TARGET_FILE`
+    TARGET_FILE=`basename $TARGET_FILE`
+done
+
+# Compute the canonicalized name by finding the physical path 
+# for the directory we're in and appending the target file.
+PHYS_DIR=`pwd -P`
+RESULT=$PHYS_DIR/$TARGET_FILE
+echo $RESULT


### PR DESCRIPTION
This improves support for macOS, since the `-f` flag doesn't exist in the macOS implementation of readlink. Not sure yet if more is needed, but this should at least be a step in the direction of macOS support.