### PR TITLE
Correct type in arg parser help string

### DIFF
--- a/util/genome_sampling.py
+++ b/util/genome_sampling.py
@@ -130,7 +130,7 @@ if __name__ == '__main__':
 		calculated. We use the larger one compared with seq_num.')
 	parser.add_argument('-d', action='store', dest='dis', default=3,
 		type=int, help='choose from the following distribution: \
-		1: beta_distribution, 2: alpha_distribution, 3: mixed_gamma_dis \
+		1: beta_distribution, 2: exponential_distribution, 3: mixed_gamma_dis \
 		default: 3. If the read length drawn from the distribution is \
 		larger than the length of the genome, the value is clipped to the\
 		length of the genome')


### PR DESCRIPTION
I think the correction distribution should be exponential rather than alpha here since you are calling the `draw_expon_dis` function.

: )